### PR TITLE
Update websocket-stream for ws 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/jacobbubu/reconnect-ws",
   "dependencies": {
     "reconnect-core": "KurentoForks/reconnect-core",
-    "websocket-stream": "~0.5.1"
+    "websocket-stream": "^3.3.3"
   },
   "devDependencies": {
     "ws": "~1.1.1"


### PR DESCRIPTION
This is PR to fix Kurento/bugtracker#116 .
It makes to use ws 1.x in websocket-stream.

To use in Kurento-client-js, It should be merged at the same time;
https://github.com/Kurento/kurento-jsonrpc-js/pull/1