### PR TITLE
Upgraded dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "homepage": "https://github.com/jacobbubu/reconnect-ws",
   "dependencies": {
     "reconnect-core": "KurentoForks/reconnect-core",
-    "websocket-stream": "~0.5.1"
+    "websocket-stream": "~5.5.0"
   },
   "devDependencies": {
-    "ws": "~1.1.1"
+    "ws": "^7.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,5 @@
   "dependencies": {
     "reconnect-core": "KurentoForks/reconnect-core",
     "websocket-stream": "~5.5.0"
-  },
-  "devDependencies": {
-    "ws": "^7.1.0"
   }
 }


### PR DESCRIPTION
Upgraded dependencies
See Kurento/bugtracker#386 for more details

I hope we have no issue with `"websocket-stream": "~5.5.0"` , I know that we have issue with `"websocket-stream": "~0.5.1"`

https://github.com/KurentoForks/reconnect-ws/blob/master/index.js#L12
I dont find `_buffer` in `"websocket-stream": "~5.5.0"` is it important?
